### PR TITLE
Add support for streamable http transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example Ruby on Rails app in the documentation
 - `FastMcp.server` now exposes the MCP server to apps that may need it to access resources
 - Automated Github Releases through Github Workflow
+- ⚠️ [Breaking] Renamed the `path_prefix` argument of rack transports to `path` for 2025-03-26 revision and streamable HTTP Transport support.
 
 ### Fixed
 - Fixed bug with Rack middlewares not being initialized properly.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ FastMcp.mount_in_rails(
   Rails.application,
   name: Rails.application.class.module_parent_name.underscore.dasherize,
   version: '1.0.0',
-  path_prefix: '/mcp' # This is the default path prefix
+  path: '/mcp' # This is the default path
   # authenticate: true,       # Uncomment to enable authentication
   # auth_token: 'your-token', # Required if authenticate: true
 ) do |server|

--- a/examples/rack_middleware.rb
+++ b/examples/rack_middleware.rb
@@ -66,7 +66,11 @@ app = lambda do |_env|
 end
 
 # Create the MCP middleware
-mcp_app = FastMcp.rack_middleware(app, name: 'example-mcp-server', version: '1.0.0') do |server|
+mcp_app = FastMcp.rack_middleware(
+  app,
+  name: 'example-mcp-server', version: '1.0.0',
+  logger: Logger.new($stdout)
+) do |server|
   # Register tool classes
   server.register_tools(GreetTool, CalculateTool)
 

--- a/examples/rails-demo-app/config/initializers/fast_mcp.rb
+++ b/examples/rails-demo-app/config/initializers/fast_mcp.rb
@@ -11,7 +11,7 @@ FastMcp.mount_in_rails(
   Rails.application,
   name: Rails.application.class.module_parent_name.underscore.dasherize,
   version: '1.0.0',
-  path_prefix: '/mcp' # This is the default path prefix
+  path: '/mcp' # This is the default path prefix
   # authenticate: true,       # Uncomment to enable authentication
   # auth_token: 'your-token', # Required if authenticate: true
 ) do |server|

--- a/lib/fast_mcp.rb
+++ b/lib/fast_mcp.rb
@@ -35,7 +35,7 @@ module FastMcp
   # @param options [Hash] Options for the middleware
   # @option options [String] :name The name of the server
   # @option options [String] :version The version of the server
-  # @option options [String] :path_prefix The path prefix for the MCP endpoints
+  # @option options [String] :path The path prefix for the MCP endpoints
   # @option options [Logger] :logger The logger to use
   # @yield [server] A block to configure the server
   # @yieldparam server [FastMcp::Server] The server to configure
@@ -117,7 +117,7 @@ module FastMcp
   # @param options [Hash] Options for the middleware
   # @option options [String] :name The name of the server
   # @option options [String] :version The version of the server
-  # @option options [String] :path_prefix The path prefix for the MCP endpoints
+  # @option options [String] :path The path prefix for the MCP endpoints
   # @option options [Logger] :logger The logger to use
   # @option options [Boolean] :authenticate Whether to use authentication
   # @option options [String] :auth_token The authentication token
@@ -129,7 +129,7 @@ module FastMcp
     name = options.delete(:name) || app.class.module_parent_name.underscore.dasherize
     version = options.delete(:version) || '1.0.0'
     logger = options[:logger] || Rails.logger
-    path_prefix = options.delete(:path_prefix) || '/mcp'
+    path = options.delete(:path) || '/mcp'
     authenticate = options.delete(:authenticate) || false
 
     options[:logger] = logger
@@ -145,7 +145,7 @@ module FastMcp
                                   end
 
     # Insert the middleware in the Rails middleware stack
-    app.middleware.use self.server.transport_klass, self.server, options.merge(path_prefix: path_prefix)
+    app.middleware.use self.server.transport_klass, self.server, options.merge(path: path)
   end
 
   # Notify the server that a resource has been updated

--- a/lib/fast_mcp.rb
+++ b/lib/fast_mcp.rb
@@ -131,10 +131,11 @@ module FastMcp
     logger = options[:logger] || Rails.logger
     path = options.delete(:path) || '/mcp'
     authenticate = options.delete(:authenticate) || false
+    streamable = options[:streamable] || false
 
     options[:logger] = logger
     # Create or get the server
-    self.server = FastMcp::Server.new(name: name, version: version, logger: logger)
+    self.server = FastMcp::Server.new(name: name, version: version, logger: logger, streamable: streamable)
     yield self.server if block_given?
 
     # Choose the right middleware based on authentication

--- a/lib/generators/fast_mcp/install/templates/fast_mcp_initializer.rb
+++ b/lib/generators/fast_mcp/install/templates/fast_mcp_initializer.rb
@@ -11,7 +11,7 @@ FastMcp.mount_in_rails(
   Rails.application,
   name: Rails.application.class.module_parent_name.underscore.dasherize,
   version: '1.0.0',
-  path_prefix: '/mcp' # This is the default path prefix
+  path: '/mcp' # This is the default path prefix
   # authenticate: true,       # Uncomment to enable authentication
   # auth_token: 'your-token', # Required if authenticate: true
 ) do |server|

--- a/lib/generators/fast_mcp/install/templates/fast_mcp_initializer.rb
+++ b/lib/generators/fast_mcp/install/templates/fast_mcp_initializer.rb
@@ -11,7 +11,9 @@ FastMcp.mount_in_rails(
   Rails.application,
   name: Rails.application.class.module_parent_name.underscore.dasherize,
   version: '1.0.0',
-  path: '/mcp' # This is the default path prefix
+  path: '/mcp' # This is the default path at which the MCP endpoint is mounted
+  # protocol_version: '2025-03-26' # Uncomment to use a specific protocol version, default is 2024-11-05 (final)
+  # streamable: true # Uncomment to enable streamable HTTP Transport with SSE, protocol version 2025-03-26 required
   # authenticate: true,       # Uncomment to enable authentication
   # auth_token: 'your-token', # Required if authenticate: true
 ) do |server|

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -217,7 +217,7 @@ module FastMcp
 
     private
 
-    PROTOCOL_VERSION = '2024-11-05'
+    PROTOCOL_VERSION = '2025-03-26'
 
     def handle_initialize(params, id)
       # Store client capabilities for later use

--- a/lib/mcp/transports/rack_transport.rb
+++ b/lib/mcp/transports/rack_transport.rb
@@ -10,21 +10,21 @@ module FastMcp
     # Rack middleware transport for MCP
     # This transport can be mounted in any Rack-compatible web framework
     class RackTransport < BaseTransport
-      DEFAULT_PATH_PREFIX = '/mcp'
+      DEFAULT_PATH = '/mcp'
 
-      attr_reader :app, :path_prefix, :sse_clients
+      attr_reader :app, :path, :sse_clients
 
       def initialize(app, server, options = {}, &_block)
         super(server, logger: options[:logger])
         @app = app
-        @path_prefix = options[:path_prefix] || DEFAULT_PATH_PREFIX
+        @path = options[:path] || DEFAULT_PATH
         @sse_clients = {}
         @running = false
       end
 
       # Start the transport
       def start
-        @logger.debug("Starting Rack transport with path prefix: #{@path_prefix}")
+        @logger.debug("Starting Rack transport with path: #{@path}")
         @running = true
       end
 
@@ -88,7 +88,7 @@ module FastMcp
         @logger.debug("Rack request path: #{path}")
 
         # Check if the request is for our MCP endpoints
-        if path.start_with?(@path_prefix)
+        if path.start_with?(@path)
           @logger.debug('Setting server transport to RackTransport')
           @server.transport = self
           handle_mcp_request(request, env)
@@ -102,7 +102,7 @@ module FastMcp
 
       # Handle MCP-specific requests
       def handle_mcp_request(request, env)
-        subpath = request.path[@path_prefix.length..]
+        subpath = request.path[@path.length..]
         @logger.info("MCP request subpath: '#{subpath.inspect}'")
 
         case subpath
@@ -300,7 +300,7 @@ module FastMcp
         io.write(": SSE connection established\n\n")
 
         # Send endpoint information as the first message
-        endpoint = "#{@path_prefix}/messages"
+        endpoint = "#{@path}/messages"
         @logger.debug("Sending endpoint information to client #{client_id}: #{endpoint}")
         io.write("event: endpoint\ndata: #{endpoint}\n\n")
 

--- a/spec/mcp/transports/rack_transport_spec.rb
+++ b/spec/mcp/transports/rack_transport_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe FastMcp::Transports::RackTransport do
       expect(transport.server).to eq(server)
       expect(transport.app).to eq(app)
       expect(transport.logger).to eq(logger)
-      expect(transport.path_prefix).to eq('/mcp')
+      expect(transport.path).to eq('/mcp')
       expect(transport.sse_clients).to eq({})
     end
 
     it 'accepts custom path prefix' do
-      custom_transport = described_class.new(server, app, path_prefix: '/api/mcp', logger: logger)
-      expect(custom_transport.path_prefix).to eq('/api/mcp')
+      custom_transport = described_class.new(server, app, path: '/api/mcp', logger: logger)
+      expect(custom_transport.path).to eq('/api/mcp')
     end
   end
 


### PR DESCRIPTION
As of writing, it is complicated to test the implementation as the mcp inspector [does not support it yet](https://github.com/modelcontextprotocol/inspector/issues/221).

Putting this on hold until then.