### PR TITLE
Fix #30 by wrapping nil response with send_response method

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -275,7 +275,7 @@ module FastMcp
       @client_initialized = true
       @logger.info('Client initialized, beginning normal operation')
 
-      send_response(nil)
+      send_result({}, nil)
     end
 
     # Handle tools/list request

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -275,7 +275,7 @@ module FastMcp
       @client_initialized = true
       @logger.info('Client initialized, beginning normal operation')
 
-      nil
+      send_response(nil)
     end
 
     # Handle tools/list request

--- a/spec/integration/server_integration_spec.rb
+++ b/spec/integration/server_integration_spec.rb
@@ -91,6 +91,17 @@ RSpec.describe 'MCP Server Integration' do
       expect(io_as_json['id']).to eq(1)
     end
 
+    it 'responds to notifications/initialized requests' do
+      request = { jsonrpc: '2.0', method: 'notifications/initialized' }
+      io_response = server.handle_request(JSON.generate(request))
+
+      io_response.rewind
+      io_as_json = JSON.parse(io_response.read)
+      expect(io_as_json['jsonrpc']).to eq('2.0')
+      expect(io_as_json['result']).to be_empty
+      expect(io_as_json['id']).to be_nil
+    end
+
     it 'lists tools' do
       request = { jsonrpc: '2.0', method: 'tools/list', id: 1 }
       io_response = server.handle_request(JSON.generate(request))

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -95,6 +95,15 @@ RSpec.describe FastMcp::Server do
       end
     end
 
+    context 'with a noticiations/initialized request' do
+      it 'responds with a empty result' do
+        request = { jsonrpc: '2.0', method: 'notifications/initialized' }.to_json
+
+        expect(server).to receive(:send_result).with({}, nil)
+        server.handle_request(request)
+      end
+    end
+
     context 'with an initialize request' do
       it 'responds with the server info' do
         request = { jsonrpc: '2.0', method: 'initialize', id: 1 }.to_json


### PR DESCRIPTION
Addresses: https://github.com/yjacquin/fast-mcp/issues/30

Trying to understand whether these requests are meant as 1-way pings without an expected response. 

If that's the case, what is the expected behaviour from rack? If not -- doing this just so the rack middleware interface is obeyed.