### PR TITLE
Fix authenticated rack middleware

### DIFF
--- a/lib/mcp/transports/authenticated_rack_transport.rb
+++ b/lib/mcp/transports/authenticated_rack_transport.rb
@@ -14,9 +14,7 @@ module FastMcp
         @auth_enabled = !@auth_token.nil?
       end
 
-      def call(env)
-        request = Rack::Request.new(env)
-
+      def handle_mcp_request(request, env)
         if auth_enabled? && !exempt_from_auth?(request.path)
           auth_header = request.env["HTTP_#{@auth_header_name.upcase.gsub('-', '_')}"]
           token = auth_header&.gsub('Bearer ', '')
@@ -42,6 +40,7 @@ module FastMcp
       end
 
       def unauthorized_response(request)
+        @logger.error('Unauthorized request: Invalid or missing authentication token')
         body = JSON.generate(
           {
             jsonrpc: '2.0',


### PR DESCRIPTION
Hey @yjacquin! Love the work you're doing with this gem, it looks really good!

I was testing the authenticated rack middleware in a Rails app and notice that it overrides the `call` method from the `RackTransport` class and checks for the auth but before actually verifying the request path actually belongs to an MCP request. This is causing other requests (non-mcp related) to return the unauthorized json response, and I think the expected behaviour should be to actually call the correct Rails endpoint.

I also created a small snippet to reproduce the error based on the Rails report bug templates:
```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  gem 'rails'
  gem 'fast-mcp', '1.1.0'
end

require 'action_controller/railtie'
require 'minitest/autorun'
require 'rack/test'
require 'fast_mcp'

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.root = __dir__
  config.eager_load = false
  config.hosts << 'example.org'
  config.secret_key_base = 'secret_key_base'

  config.logger = Logger.new($stdout)
end

FastMcp.mount_in_rails(
  Rails.application,
  name: 'minimial_app',
  version: '1.0.0',
  path_prefix: '/mcp',
  messages_route: 'messages',
  sse_route: 'sse',
  authenticate: true,
  auth_token: '123123',
  logger: Logger.new($stdout)
)

Rails.application.initialize!

Rails.application.routes.draw do
  get '/', to: 'test#index'
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    render plain: 'Home'
  end
end

class BugTest < ActiveSupport::TestCase
  include Rack::Test::Methods

  def test_returns_error_when_not_authenticated
    get '/'
    refute last_response.ok?
    assert_equal JSON.parse(last_response.body)['error']['message'],
                 'Unauthorized: Invalid or missing authentication token'
  end

  private

  def app
    Rails.application
  end
end
```


Please let me know if you think we should include some tests for this integration or anything else you want me to add/change here! 🙂 