### PR TITLE
Declare rack as an explicit dependency, since RackTransport requires it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ end
 # Gems required for examples
 group :examples do
   gem 'puma'
-  gem 'rack'
   gem 'rackup', '~> 2.2'
   gem 'sinatra'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       dry-schema (~> 1.14)
       json (~> 2.0)
       mime-types (~> 3.4)
+      rack (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -134,7 +135,6 @@ DEPENDENCIES
   mime-types (~> 3.4)
   pry
   puma
-  rack
   rackup (~> 2.2)
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/fast-mcp.gemspec
+++ b/fast-mcp.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-schema', '~> 1.14'
   spec.add_dependency 'json', '~> 2.0'
   spec.add_dependency 'mime-types', '~> 3.4'
+  spec.add_dependency 'rack', '~> 3.1'
 
   # Development dependencies are specified in the Gemfile
 end


### PR DESCRIPTION
thank you for making this awesome gem! Right now it gem depends on `rack` only through the `examples` group in `Gemfile`, but the gem's code assumes that `rack` is installed in operational environments. 

`RackTransport` requires `rack`: https://github.com/yjacquin/fast-mcp/blob/0d23f751cfda8c860457e7393650c39cf322dd1b/lib/mcp/transports/rack_transport.rb#L5

This commit declares an explicit dependency on `rack` in the gemspec, so that the gem can be used in systems where `rack` is not already installed.

Fixes #34 