### PR TITLE
🔧 Fix notifications/initialized response

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -275,7 +275,7 @@ module FastMcp
       @client_initialized = true
       @logger.info('Client initialized, beginning normal operation')
 
-      send_result({}, nil)
+      nil
     end
 
     # Handle tools/list request

--- a/spec/integration/server_integration_spec.rb
+++ b/spec/integration/server_integration_spec.rb
@@ -91,15 +91,11 @@ RSpec.describe 'MCP Server Integration' do
       expect(io_as_json['id']).to eq(1)
     end
 
-    it 'responds to notifications/initialized requests' do
+    it 'responds nil to notifications/initialized requests' do
       request = { jsonrpc: '2.0', method: 'notifications/initialized' }
       io_response = server.handle_request(JSON.generate(request))
 
-      io_response.rewind
-      io_as_json = JSON.parse(io_response.read)
-      expect(io_as_json['jsonrpc']).to eq('2.0')
-      expect(io_as_json['result']).to be_empty
-      expect(io_as_json['id']).to be_nil
+      expect(io_response).to be_nil
     end
 
     it 'lists tools' do

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -95,12 +95,12 @@ RSpec.describe FastMcp::Server do
       end
     end
 
-    context 'with a noticiations/initialized request' do
-      it 'responds with a empty result' do
+    context 'with a notifications/initialized request' do
+      it 'responds with nil' do
         request = { jsonrpc: '2.0', method: 'notifications/initialized' }.to_json
 
-        expect(server).to receive(:send_result).with({}, nil)
-        server.handle_request(request)
+        response = server.handle_request(request)
+        expect(response).to be_nil
       end
     end
 


### PR DESCRIPTION
It used to respond with an empty result but we should not respond at all.