### PR TITLE
✨Implement resource templates

### DIFF
--- a/lib/mcp/resource.rb
+++ b/lib/mcp/resource.rb
@@ -11,13 +11,71 @@ module FastMcp
   class Resource
     class << self
       attr_accessor :server
+      attr_reader :template_params
 
       # Define URI for this resource
       # @param value [String, nil] The URI for this resource
       # @return [String] The URI for this resource
       def uri(value = nil)
-        @uri = value if value
+        if value
+          @uri = value
+          # Check if URI contains template parameters
+          if value.include?('{') && value.include?('}')
+            @is_template = true
+            @template_params = value.scan(/\{([^\}]+)\}/).flatten
+
+            # Generate a regex pattern for matching this URI
+            escaped_uri = Regexp.escape(value)
+
+            @template_params.each do |param|
+              escaped_param = Regexp.escape("{#{param}}")
+              escaped_uri = escaped_uri.sub(escaped_param, '([^/]+)')
+            end
+
+            @uri_pattern = Regexp.new("^#{escaped_uri}$")
+          else
+            @is_template = false
+            @template_params = nil
+            @uri_pattern = nil
+          end
+        end
         @uri || (superclass.respond_to?(:uri) ? superclass.uri : nil)
+      end
+
+      # Check if this resource has a templated URI
+      # @return [Boolean] true if the URI contains template parameters
+      def templated?
+        @is_template || false
+      end
+
+      # Get the regex pattern for matching this URI
+      # @return [Regexp, nil] The pattern for matching this URI
+      def uri_pattern
+        @uri_pattern || (superclass.respond_to?(:uri_pattern) && superclass.templated? ? superclass.uri_pattern : nil)
+      end
+
+      # Create a new instance with the given params
+      # @param params [Hash] The parameters for this resource instance
+      # @return [Resource] A new resource instance
+      def with_params(params)
+        resource_class = Class.new(self)
+        resource_class.instance_variable_set(:@params, params)
+
+        resource_class.define_singleton_method(:instance) do
+          @instance ||= begin
+            instance = new
+            instance.instance_variable_set(:@params, params)
+            instance
+          end
+        end
+
+        resource_class
+      end
+
+      # Get the parameters for this resource instance
+      # @return [Hash] The parameters for this resource instance
+      def params
+        @params || {}
       end
 
       # Define name for this resource
@@ -26,6 +84,13 @@ module FastMcp
       def resource_name(value = nil)
         @name = value if value
         @name || (superclass.respond_to?(:resource_name) ? superclass.resource_name : nil)
+      end
+
+      alias original_name name
+      def name
+        return resource_name if resource_name
+
+        original_name
       end
 
       # Define description for this resource
@@ -47,12 +112,21 @@ module FastMcp
       # Get the resource metadata (without content)
       # @return [Hash] Resource metadata
       def metadata
-        {
-          uri: uri,
-          name: resource_name,
-          description: description,
-          mimeType: mime_type
-        }.compact
+        if templated?
+          {
+            uriTemplate: uri,
+            name: resource_name,
+            description: description,
+            mimeType: mime_type
+          }.compact
+        else
+          {
+            uri: uri,
+            name: resource_name,
+            description: description,
+            mimeType: mime_type
+          }.compact
+        end
       end
 
       # Load content from a file (class method)
@@ -89,6 +163,11 @@ module FastMcp
 
     include Singleton
 
+    # Initialize with instance variables
+    def initialize
+      @params = {}
+    end
+
     # URI of the resource - delegates to class method
     # @return [String, nil] The URI for this resource
     def uri
@@ -98,7 +177,7 @@ module FastMcp
     # Name of the resource - delegates to class method
     # @return [String, nil] The name for this resource
     def name
-      self.class.name
+      self.class.resource_name
     end
 
     # Description of the resource - delegates to class method
@@ -111,6 +190,12 @@ module FastMcp
     # @return [String, nil] The MIME type for this resource
     def mime_type
       self.class.mime_type
+    end
+
+    # Get parameters from the URI template
+    # @return [Hash] The parameters extracted from the URI
+    def params
+      @params || self.class.params
     end
 
     # Method to be overridden by subclasses to dynamically generate content

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -28,6 +28,7 @@ module FastMcp
       @version = version
       @tools = {}
       @resources = {}
+      @templated_resources = []
       @resource_subscriptions = {}
       @logger = logger
       @logger.level = Logger::INFO
@@ -66,8 +67,15 @@ module FastMcp
 
     # Register a resource with the server
     def register_resource(resource)
-      @resources[resource.uri] = resource
-      @logger.debug("Registered resource: #{resource.name} (#{resource.uri})")
+      # Store templated resources separately for URI matching
+      if resource.templated?
+        @templated_resources ||= []
+        @templated_resources << resource
+      else
+        @resources[resource.uri] = resource
+      end
+
+      @logger.debug("Registered resource: #{resource.resource_name} (#{resource.uri})")
       resource.server = self
       # Notify subscribers about the list change
       notify_resource_list_changed if @transport
@@ -164,6 +172,8 @@ module FastMcp
         handle_tools_call(params, id)
       when 'resources/list'
         handle_resources_list(id)
+      when 'resources/templates/list'
+        handle_resources_templates_list(id)
       when 'resources/read'
         handle_resources_read(params, id)
       when 'resources/subscribe'
@@ -191,6 +201,30 @@ module FastMcp
     # Read a resource directly
     def read_resource(uri)
       resource = @resources[uri]
+
+      if !resource && @templated_resources && !@templated_resources.empty?
+        @logger.debug('Resource not found in direct mapping, checking templated resources')
+        @templated_resources.each do |template_resource|
+          next unless template_resource.uri_pattern
+
+          @logger.debug("Testing pattern: #{template_resource.uri_pattern.inspect} against URI: #{uri}")
+
+          next unless match = template_resource.uri_pattern.match(uri)
+
+          @logger.debug("Pattern matched: #{match.inspect}")
+
+          params = {}
+          template_resource.template_params.each_with_index do |param, i|
+            params[param.to_sym] = match[i + 1]
+          end
+          @logger.debug("Extracted params: #{params.inspect}")
+
+          resource = template_resource.with_params(params)
+          @logger.debug("Created resource with params: #{resource.inspect}")
+          break
+        end
+      end
+
       raise "Resource not found: #{uri}" unless resource
 
       resource
@@ -249,24 +283,33 @@ module FastMcp
 
       return send_error(-32_602, 'Invalid params: missing resource URI', id) unless uri
 
-      resource = @resources[uri]
-      return send_error(-32_602, "Resource not found: #{uri}", id) unless resource
+      @logger.debug("Looking for resource with URI: #{uri}")
 
-      base_content = { uri: resource.uri }
-      base_content[:mimeType] = resource.mime_type if resource.mime_type
-      resource_instance = resource.instance
-      # Format the response according to the MCP specification
-      result = if resource_instance.binary?
-                 {
-                   contents: [base_content.merge(blob: Base64.strict_encode64(resource_instance.content))]
-                 }
-               else
-                 {
-                   contents: [base_content.merge(text: resource_instance.content)]
-                 }
-               end
+      begin
+        resource = read_resource(uri)
+        @logger.debug("Found resource: #{resource.resource_name}, templated: #{resource.templated?}")
 
-      send_result(result, id)
+        base_content = { uri: uri }
+        base_content[:mimeType] = resource.mime_type if resource.mime_type
+        resource_instance = resource.instance
+        @logger.debug("Resource instance params: #{resource_instance.params.inspect}")
+
+        result = if resource_instance.binary?
+                   {
+                     contents: [base_content.merge(blob: Base64.strict_encode64(resource_instance.content))]
+                   }
+                 else
+                   {
+                     contents: [base_content.merge(text: resource_instance.content)]
+                   }
+                 end
+
+        send_result(result, id)
+      rescue StandardError => e
+        @logger.error("Error reading resource: #{e.message}")
+        @logger.error(e.backtrace.join("\n"))
+        send_error(-32_602, "Resource not found: #{uri}", id)
+      end
     end
 
     def handle_initialized_notification
@@ -349,6 +392,14 @@ module FastMcp
       resources_list = @resources.values.map(&:metadata)
 
       send_result({ resources: resources_list }, id)
+    end
+
+    # Handle resources/templates/list request
+    def handle_resources_templates_list(id)
+      # Collect templated resources
+      templated_resources_list = (@templated_resources || []).map(&:metadata)
+
+      send_result({ resourceTemplates: templated_resources_list }, id)
     end
 
     # Handle resources/subscribe request


### PR DESCRIPTION
Adds resource templates to the existing resource DSL. A resourced template is any url containing `{` or `}`, which I think should be safe as they're reserved characters.

`params` made available to the instance

```ruby
 Class.new(FastMcp::Resource) do
      uri 'test/counter/{id}'
      resource_name 'Test Counter with ID'
      description 'A test counter resource with ID parameter'
      mime_type 'application/json'

      def initialize
        @count = 0
      end

      def content
        JSON.generate({ count: @count, id: params[:id] })
      end

      def update_count(new_count)
        @count = new_count
      end
    end
```

I've lightly tested this in the inspector, but opening early as I'm sure you know more about MCP and if this is correct than I do.
