### PR TITLE
✨ Expose headers to tools

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,6 +17,7 @@ Tools are a core concept in the Model Context Protocol (MCP). They allow you to 
   - [Tool Categories](#tool-categories)
   - [Tool Metadata](#tool-metadata)
   - [Tool Permissions](#tool-permissions)
+  - [Request Headers](#request-headers)
 - [Best Practices](#best-practices)
 - [Examples](#examples)
 
@@ -357,6 +358,18 @@ class AdminActionTool < FastMcp::Tool
 
     # Perform the action
     "Admin action '#{action}' performed successfully"
+  end
+end
+```
+
+### Request Headers
+
+When using the Rack transport, HTTP headers from tool call requests are exposed to tools via the `headers` method:
+
+```ruby
+class MyTool < FastMcp::Tool
+  def call
+    "Host header is #{headers["HOST"]}"
   end
 end
 ```

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -133,7 +133,7 @@ module FastMcp
     end
 
     # Handle incoming JSON-RPC request
-    def handle_request(json_str) # rubocop:disable Metrics/MethodLength
+    def handle_request(json_str, headers: {}) # rubocop:disable Metrics/MethodLength
       begin
         request = JSON.parse(json_str)
       rescue JSON::ParserError, TypeError
@@ -161,7 +161,7 @@ module FastMcp
       when 'tools/list'
         handle_tools_list(id)
       when 'tools/call'
-        handle_tools_call(params, id)
+        handle_tools_call(params, headers, id)
       when 'resources/list'
         handle_resources_list(id)
       when 'resources/read'
@@ -179,12 +179,12 @@ module FastMcp
     end
 
     # Handle a JSON-RPC request and return the response as a JSON string
-    def handle_json_request(request)
+    def handle_json_request(request, headers: {})
       # Process the request
       if request.is_a?(String)
-        handle_request(request)
+        handle_request(request, headers: headers)
       else
-        handle_request(JSON.generate(request))
+        handle_request(JSON.generate(request), headers: headers)
       end
     end
 
@@ -292,7 +292,7 @@ module FastMcp
     end
 
     # Handle tools/call request
-    def handle_tools_call(params, id)
+    def handle_tools_call(params, headers, id)
       tool_name = params['name']
       arguments = params['arguments'] || {}
 
@@ -304,7 +304,7 @@ module FastMcp
       begin
         # Convert string keys to symbols for Ruby
         symbolized_args = symbolize_keys(arguments)
-        result, metadata = tool.new.call_with_schema_validation!(**symbolized_args)
+        result, metadata = tool.new(headers: headers).call_with_schema_validation!(**symbolized_args)
 
         # Format and send the result
         send_formatted_result(result, id, metadata)

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -126,11 +126,13 @@ module FastMcp
       end
     end
 
-    def initialize
+    def initialize(headers: {})
       @_meta = {}
+      @headers = headers
     end
 
     attr_accessor :_meta
+    attr_reader :headers
 
     def notify_resource_updated(uri)
       self.class.server.notify_resource_updated(uri)

--- a/lib/mcp/transports/base_transport.rb
+++ b/lib/mcp/transports/base_transport.rb
@@ -32,8 +32,8 @@ module FastMcp
 
       # Process an incoming message
       # This is a helper method that can be used by subclasses
-      def process_message(message)
-        server.handle_json_request(message)
+      def process_message(message, headers: {})
+        server.handle_json_request(message, headers: headers)
       end
     end
   end

--- a/lib/mcp/transports/rack_transport.rb
+++ b/lib/mcp/transports/rack_transport.rb
@@ -503,7 +503,15 @@ module FastMcp
         # Parse the request body
         body = request.body.read
 
-        response = process_message(body) || []
+        # Assemble HTTP headers
+        headers = request.each_header.filter_map do |key, value|
+          if (match = /^HTTP_(?<name>.*)/.match(key))
+            header_name = match[:name]
+            [header_name, value]
+          end
+        end.to_h
+
+        response = process_message(body, headers: headers) || []
         @logger.info("Response: #{response}")
 
         [200, { 'Content-Type' => 'application/json' }, response]

--- a/spec/mcp/tool_spec.rb
+++ b/spec/mcp/tool_spec.rb
@@ -137,6 +137,29 @@ RSpec.describe FastMcp::Tool do
     end
   end
 
+  describe '#headers' do
+    let(:test_class) do
+      Class.new(described_class) do
+        def self.name
+          'test-tool'
+        end
+
+        def self.description
+          'A test tool'
+        end
+
+        def call(**_args)
+          "Hello, #{headers['ENTITY']}!"
+        end
+      end
+    end
+
+    it 'can read headers' do
+      tool = test_class.new(headers: { 'ENTITY' => 'World' })
+      expect(tool.call).to eq('Hello, World!')
+    end
+  end
+
   describe 'SchemaCompiler' do
     let(:compiler) { FastMcp::SchemaCompiler.new }
 

--- a/spec/mcp/transports/authenticated_rack_transport_spec.rb
+++ b/spec/mcp/transports/authenticated_rack_transport_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe FastMcp::Transports::AuthenticatedRackTransport do
 
         # The RackTransport class will call server.handle_json_request with the message
         json_response = '{"jsonrpc":"2.0","result":{},"id":1}'
-        expect(server).to receive(:handle_json_request).with(json_message).and_return(json_response)
+        expect(server).to receive(:handle_json_request).with(json_message, headers: { 'AUTHORIZATION' => env['HTTP_AUTHORIZATION'] }).and_return(json_response)
 
         # For MCP paths, we don't expect app.call to be invoked
         expect(app).not_to receive(:call)
@@ -324,7 +324,7 @@ RSpec.describe FastMcp::Transports::AuthenticatedRackTransport do
 
         expect(server).to receive(:transport=).with(transport)
         expect(server).to receive(:handle_json_request)
-          .with('{"jsonrpc":"2.0","method":"ping","id":1}')
+          .with('{"jsonrpc":"2.0","method":"ping","id":1}', headers: { 'ORIGIN' => env['HTTP_ORIGIN'], 'AUTHORIZATION' => env['HTTP_AUTHORIZATION'] })
           .and_return('{"jsonrpc":"2.0","result":{},"id":1}')
 
         result = transport.call(env)

--- a/spec/mcp/transports/rack_transport_spec.rb
+++ b/spec/mcp/transports/rack_transport_spec.rb
@@ -183,10 +183,11 @@ RSpec.describe FastMcp::Transports::RackTransport do
           host: 'localhost'
         )
         allow(Rack::Request).to receive(:new).with(env).and_return(request)
+        allow(request).to receive(:each_header).and_return(env.each)
 
         expect(server).to receive(:transport=).with(transport)
         expect(server).to receive(:handle_json_request)
-          .with('{"jsonrpc":"2.0","method":"ping","id":1}')
+          .with('{"jsonrpc":"2.0","method":"ping","id":1}', headers: { 'ORIGIN' => env['HTTP_ORIGIN'] })
           .and_return('{"jsonrpc":"2.0","result":{},"id":1}')
 
         result = transport.call(env)
@@ -280,7 +281,7 @@ RSpec.describe FastMcp::Transports::RackTransport do
         expect(server).to receive(:transport=).with(transport)
         # Mock the behavior for a valid Origin
         expect(server).to receive(:handle_json_request)
-          .with('{"jsonrpc":"2.0","method":"ping","id":1}')
+          .with('{"jsonrpc":"2.0","method":"ping","id":1}', headers: { 'ORIGIN' => env['HTTP_ORIGIN'] })
           .and_return('{"jsonrpc":"2.0","result":{},"id":1}')
 
         result = transport.call(env)
@@ -322,7 +323,7 @@ RSpec.describe FastMcp::Transports::RackTransport do
 
         expect(server).to receive(:transport=).with(transport)
         expect(server).to receive(:handle_json_request)
-          .with('{"jsonrpc":"2.0","method":"ping","id":1}')
+          .with('{"jsonrpc":"2.0","method":"ping","id":1}', headers: { 'REFERER' => env['HTTP_REFERER'] })
           .and_return('{"jsonrpc":"2.0","result":{},"id":1}')
 
         result = transport.call(env)
@@ -340,7 +341,7 @@ RSpec.describe FastMcp::Transports::RackTransport do
 
         expect(server).to receive(:transport=).with(transport)
         expect(server).to receive(:handle_json_request)
-          .with('{"jsonrpc":"2.0","method":"ping","id":1}')
+          .with('{"jsonrpc":"2.0","method":"ping","id":1}', headers: { 'HOST' => env['HTTP_HOST'] })
           .and_return('{"jsonrpc":"2.0","result":{},"id":1}')
 
         result = transport.call(env)
@@ -453,7 +454,7 @@ RSpec.describe FastMcp::Transports::RackTransport do
 
         # Mock the server's handle_json_request method
         expect(server).to receive(:handle_json_request)
-          .with('{"jsonrpc":"2.0","method":"ping","id":1}')
+          .with('{"jsonrpc":"2.0","method":"ping","id":1}', headers: {})
           .and_return('{"jsonrpc":"2.0","result":{},"id":1}')
 
         result = transport.call(env)


### PR DESCRIPTION
### ✨ Expose Request Headers to Tool Calls

This PR introduces support for passing request headers into tools, allowing them to access contextual information during execution. This was inspired by discussion [on issue #24](https://github.com/yjacquin/fast-mcp/issues/24).

---

#### 📦 **Header Access**
- Tools now receive request headers via their initializer.
- Enables use cases such as:
  - Reading authentication tokens
  - Accessing client metadata
  - Customizing behavior based on request context

---

#### ✅ **Tests**
- Added tests to verify that headers are correctly passed and accessible within tools.

---

This lays the groundwork for more context-aware and secure tool behavior.