### PR TITLE
✨ Authorize requests before invoking tools

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -304,7 +304,13 @@ module FastMcp
       begin
         # Convert string keys to symbols for Ruby
         symbolized_args = symbolize_keys(arguments)
-        result, metadata = tool.new(headers: headers).call_with_schema_validation!(**symbolized_args)
+
+        tool_instance = tool.new(headers: headers)
+        authorized = tool_instance.authorized?(**symbolized_args)
+
+        return send_error(-32_602, 'Unauthorized', id) unless authorized
+
+        result, metadata = tool_instance.call_with_schema_validation!(**symbolized_args)
 
         # Format and send the result
         send_formatted_result(result, id, metadata)

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -115,7 +115,8 @@ module FastMcp
       end
 
       def authorize(&block)
-        @authorization_block = block
+        @authorization_blocks ||= []
+        @authorization_blocks.push block
       end
 
       def call(**args)
@@ -136,10 +137,10 @@ module FastMcp
     end
 
     def authorized?(**args)
-      auth_checks = [self.class, *self.class.ancestors].filter_map do |ancestor|
+      auth_checks = self.class.ancestors.filter_map do |ancestor|
         ancestor.ancestors.include?(FastMcp::Tool) &&
-          ancestor.instance_variable_get(:@authorization_block)
-      end
+          ancestor.instance_variable_get(:@authorization_blocks)
+      end.flatten
 
       return true if auth_checks.empty?
 


### PR DESCRIPTION
# ❗️ This PR depends on #78 
The features were developed in tandem, and are documented together. I split #78 off because it is the more important feature to my mind, and is the more easily reviewed changeset.

### 🔐 Add Authorization Support for Tool Calls

This PR introduces **authorization support** for tools, enabling fine-grained access control before tool invocation.

---

#### ✅ **Authorization Blocks**
- Tools can now define one or more `.authorize` blocks.
- These blocks are executed **before the tool's `call` method**.
- If any block returns a falsey value, the tool call is **denied**.

---

#### 🧩 **Composable Authorization**
- Authorization can be composed using:
  - Inherited `.authorize` blocks from parent classes.
  - Additional `.authorize` blocks defined directly on the tool.
  - Modules that include shared authorization logic.
- **All authorization checks must pass** for the tool to be invoked.

---

#### 📝 **Documentation Updates**
- Added new sections to `docs/tools.md`:
  - **Authentication and Authorization**: Describes how to access headers and define authorization logic.
  - **Composing Tool Authentication**: Shows how to modularize and reuse authentication logic with examples.

---

This feature provides a robust mechanism for securing tool access based on user identity, roles, or request context.
