### PR TITLE
Add ability to pass context to tools & implement env context extraction for Rack

### DIFF
--- a/lib/fast_mcp.rb
+++ b/lib/fast_mcp.rb
@@ -126,6 +126,7 @@ module FastMcp
   # @option options [String] :sse_route The route for the SSE endpoint
   # @option options [Logger] :logger The logger to use
   # @option options [Boolean] :authenticate Whether to use authentication
+  # @option options [Class] :authentication_klass The authentication class to use
   # @option options [String] :auth_token The authentication token
   # @option options [Array<String,Regexp>] :allowed_origins List of allowed origins for DNS rebinding protection
   # @yield [server] A block to configure the server
@@ -154,7 +155,7 @@ module FastMcp
 
     # Choose the right middleware based on authentication
     self.server.transport_klass = if authenticate
-                                    FastMcp::Transports::AuthenticatedRackTransport
+                                    authentication_klass
                                   else
                                     FastMcp::Transports::RackTransport
                                   end

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -133,7 +133,7 @@ module FastMcp
     end
 
     # Handle incoming JSON-RPC request
-    def handle_request(json_str) # rubocop:disable Metrics/MethodLength
+    def handle_request(json_str, context = {}) # rubocop:disable Metrics/MethodLength
       begin
         request = JSON.parse(json_str)
       rescue JSON::ParserError, TypeError
@@ -161,7 +161,7 @@ module FastMcp
       when 'tools/list'
         handle_tools_list(id)
       when 'tools/call'
-        handle_tools_call(params, id)
+        handle_tools_call(params, id, context)
       when 'resources/list'
         handle_resources_list(id)
       when 'resources/read'
@@ -179,12 +179,12 @@ module FastMcp
     end
 
     # Handle a JSON-RPC request and return the response as a JSON string
-    def handle_json_request(request)
+    def handle_json_request(request, context = {})
       # Process the request
       if request.is_a?(String)
-        handle_request(request)
+        handle_request(request, context)
       else
-        handle_request(JSON.generate(request))
+        handle_request(JSON.generate(request), context)
       end
     end
 
@@ -292,7 +292,7 @@ module FastMcp
     end
 
     # Handle tools/call request
-    def handle_tools_call(params, id)
+    def handle_tools_call(params, id, context = {})
       tool_name = params['name']
       arguments = params['arguments'] || {}
 
@@ -304,7 +304,9 @@ module FastMcp
       begin
         # Convert string keys to symbols for Ruby
         symbolized_args = symbolize_keys(arguments)
-        result, metadata = tool.new.call_with_schema_validation!(**symbolized_args)
+        tool_instance = tool.new
+        tool_instance.context = context
+        result, metadata = tool_instance.call_with_schema_validation!(**symbolized_args)
 
         # Format and send the result
         send_formatted_result(result, id, metadata)

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -91,6 +91,8 @@ module FastMcp
   class Tool
     class InvalidArgumentsError < StandardError; end
 
+    attr_accessor :context
+
     class << self
       attr_accessor :server
 
@@ -128,6 +130,7 @@ module FastMcp
 
     def initialize
       @_meta = {}
+      @context = nil
     end
 
     attr_accessor :_meta

--- a/lib/mcp/transports/base_transport.rb
+++ b/lib/mcp/transports/base_transport.rb
@@ -32,8 +32,8 @@ module FastMcp
 
       # Process an incoming message
       # This is a helper method that can be used by subclasses
-      def process_message(message)
-        server.handle_json_request(message)
+      def process_message(message, context = {})
+        server.handle_json_request(message, context)
       end
     end
   end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -191,6 +191,31 @@ RSpec.describe FastMcp::Server do
         )
         server.handle_request(request)
       end
+      
+      it 'calls a tool with context' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'test-tool',
+            arguments: {
+              name: 'username'
+            }
+          },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_result).with(
+          { content: [{ text: 'Hello, username!', type: 'text' }], isError: false },
+          1,
+          metadata: {}
+        )
+
+        context = { user_role: 'admin', user_id: '123' }
+        expect_any_instance_of(test_tool_class).to receive(:context=).with(context)
+        
+        server.handle_request(request, context)
+      end
 
       it "returns an error if the tool doesn't exist" do
         request = {


### PR DESCRIPTION
## Adding the context of requesting user to tools

For a project I'm working on, I need to do authorization at the tool call level. I would like to be able to apply custom authentication checks in the transport layer (rack) and preserve context of that authenticated requester for tool level authorization.

Since I'm using the rails integration (rack + puma) thread safety of context is a concern, so rather than storing this context in the transport class instance itself, I'm passing the context as an argument through the server.

I've only scratched out implementation for `tools/call`. If this project would like to use this approach further I can help on implementation. I believe there are a few potential implementation paths being explored at the moment, just sharing back what I did to unblock on my fork should it be of use!




----
### Sample Code
**Initialization**
```rb
 FastMcp.mount_in_rails(
    Rails.application,
    name: Rails.application.class.module_parent_name.underscore.dasherize,
    version: '1.0.0',
    path_prefix: '/mcp', # This is the default path prefix
    messages_route: 'messages', # This is the default route for the messages endpoint
    sse_route: 'sse', # This is the default route for the SSE endpoint
    authenticate: true, # Uncomment to enable authentication
    authenticate_with: Mcp::Transports::DeviseRackTransport # use custom auth solution, not a specific auth token
  ) do |server|
    # ...
  end
```

**Authentication**
* AuthenticedRackTransport now performs authorization checks in `auth_check` which receives the bearer token & rack reqest / env.
* Inheriting classes can overwrite the auth check for their own need. Example below checks an ActiveRecord User's token (akin to using Devise).
* The user is stored in rack `env` to stay in the current request thread's stack (instead of in the registered server which could be multi-threaded).
* The context is generated in `extract_context_from_env` to keep a uniform context concept when passing from rack transport -> server class

```rb
module Mcp
  module Transports
    class DeviseRackTransport < FastMcp::Transports::AuthenticatedRackTransport

      private

      def auth_check(token, request, env)
        user = User.find_by(token: token)

        # return an unauth response to fail the check
        return unauthorized_response(request, 'Insufficient permissions') unless user&.admin?

        # stash the user in the rack env
        env['mcp.current_user'] = user

        # return nil to pass the check
        nil
      end

      # called by the rack transport to generate the context to pass to the server level of request handling
      def extract_context_from_env(env)
        {
          current_user: env['mcp.current_user']
        }
      end

      def auth_enabled?
        true
      end
    end
  end
end
```

**Authorization**
* Simple example here, now that the context is applied to the tool, the current_user can be accessed
* If you use pundit you can use this model for doing `authorize` calls.

```rb
module Mcp
  module Tools
    class BookLookupTool < ApplicationTool
      tool_name 'find_book'

      description <<~DESC
        Lookups up books the requesting user has access to
      DESC

      def call 
        current_user.books
      end

      # gets current user out of the context
      def current_user
        context[:current_user]
      end
    end
  end
end
```