### PR TITLE
Update SSE implementation for client-specific messaging

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -328,7 +328,13 @@ module FastMcp
       if result.is_a?(Hash) && result.key?(:content)
         send_result(result, id, client_id, metadata: metadata)
       else
-        send_result({ content: result }, id, client_id, metadata: metadata)
+        # Format the result according to the MCP specification
+        formatted_result = {
+          content: [{ type: 'text', text: result.to_s }],
+          isError: false
+        }
+
+        send_result(formatted_result, id, client_id, metadata: metadata)
       end
     end
 
@@ -340,7 +346,7 @@ module FastMcp
         isError: true
       }
 
-      send_response(error_result, client_id)
+      send_result(error_result, id, client_id)
     end
 
     # Handle resources/list request

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -133,18 +133,19 @@ module FastMcp
     end
 
     # Handle incoming JSON-RPC request
-    def handle_request(json_str) # rubocop:disable Metrics/MethodLength
+    def handle_request(json_str, context = {}) # rubocop:disable Metrics/MethodLength
+      client_id = context[:client_id]
       begin
         request = JSON.parse(json_str)
       rescue JSON::ParserError, TypeError
-        return send_error(-32_600, 'Invalid Request', nil)
+        return send_error(-32_600, 'Invalid Request', nil, client_id)
       end
 
       @logger.debug("Received request: #{request.inspect}")
 
       # Check if it's a valid JSON-RPC 2.0 request
       unless request['jsonrpc'] == '2.0' && request['method']
-        return send_error(-32_600, 'Invalid Request', request['id'])
+        return send_error(-32_600, 'Invalid Request', request['id'], client_id)
       end
 
       method = request['method']
@@ -153,38 +154,38 @@ module FastMcp
 
       case method
       when 'ping'
-        send_result({}, id)
+        send_result({}, id, client_id)
       when 'initialize'
-        handle_initialize(params, id)
+        handle_initialize(params, id, context)
       when 'notifications/initialized'
         handle_initialized_notification
       when 'tools/list'
-        handle_tools_list(id)
+        handle_tools_list(id, context)
       when 'tools/call'
-        handle_tools_call(params, id)
+        handle_tools_call(params, id, context)
       when 'resources/list'
-        handle_resources_list(id)
+        handle_resources_list(id, context)
       when 'resources/read'
-        handle_resources_read(params, id)
+        handle_resources_read(params, id, context)
       when 'resources/subscribe'
-        handle_resources_subscribe(params, id)
+        handle_resources_subscribe(params, id, context)
       when 'resources/unsubscribe'
-        handle_resources_unsubscribe(params, id)
+        handle_resources_unsubscribe(params, id, context)
       else
-        send_error(-32_601, "Method not found: #{method}", id)
+        send_error(-32_601, "Method not found: #{method}", id, client_id)
       end
     rescue StandardError => e
       @logger.error("Error handling request: #{e.message}, #{e.backtrace.join("\n")}")
-      send_error(-32_600, "Internal error: #{e.message}", id)
+      send_error(-32_600, "Internal error: #{e.message}", id, client_id)
     end
 
     # Handle a JSON-RPC request and return the response as a JSON string
-    def handle_json_request(request)
+    def handle_json_request(request, context = {})
       # Process the request
       if request.is_a?(String)
-        handle_request(request)
+        handle_request(request, context)
       else
-        handle_request(JSON.generate(request))
+        handle_request(JSON.generate(request), context)
       end
     end
 
@@ -219,10 +220,11 @@ module FastMcp
 
     PROTOCOL_VERSION = '2024-11-05'
 
-    def handle_initialize(params, id)
+    def handle_initialize(params, id, context)
       # Store client capabilities for later use
       @client_capabilities = params['capabilities'] || {}
       client_info = params['clientInfo'] || {}
+      client_id = context[:client_id]
 
       # Log client information
       @logger.info("Client connected: #{client_info['name']} v#{client_info['version']}")
@@ -240,17 +242,18 @@ module FastMcp
 
       @logger.info("Server response: #{response.inspect}")
 
-      send_result(response, id)
+      send_result(response, id, client_id)
     end
 
     # Handle a resource read
-    def handle_resources_read(params, id)
+    def handle_resources_read(params, id, context)
       uri = params['uri']
+      client_id = context[:client_id]
 
-      return send_error(-32_602, 'Invalid params: missing resource URI', id) unless uri
+      return send_error(-32_602, 'Invalid params: missing resource URI', id, client_id) unless uri
 
       resource = @resources[uri]
-      return send_error(-32_602, "Resource not found: #{uri}", id) unless resource
+      return send_error(-32_602, "Resource not found: #{uri}", id, client_id) unless resource
 
       base_content = { uri: resource.uri }
       base_content[:mimeType] = resource.mime_type if resource.mime_type
@@ -266,7 +269,7 @@ module FastMcp
                  }
                end
 
-      send_result(result, id)
+      send_result(result, id, client_id)
     end
 
     def handle_initialized_notification
@@ -279,7 +282,8 @@ module FastMcp
     end
 
     # Handle tools/list request
-    def handle_tools_list(id)
+    def handle_tools_list(id, context)
+      client_id = context[:client_id]
       tools_list = @tools.values.map do |tool|
         {
           name: tool.tool_name,
@@ -288,18 +292,19 @@ module FastMcp
         }
       end
 
-      send_result({ tools: tools_list }, id)
+      send_result({ tools: tools_list }, id, client_id)
     end
 
     # Handle tools/call request
-    def handle_tools_call(params, id)
+    def handle_tools_call(params, id, context = {})
       tool_name = params['name']
       arguments = params['arguments'] || {}
+      client_id = context[:client_id]
 
-      return send_error(-32_602, 'Invalid params: missing tool name', id) unless tool_name
+      return send_error(-32_602, 'Invalid params: missing tool name', id, client_id) unless tool_name
 
       tool = @tools[tool_name]
-      return send_error(-32_602, "Tool not found: #{tool_name}", id) unless tool
+      return send_error(-32_602, "Tool not found: #{tool_name}", id, client_id) unless tool
 
       begin
         # Convert string keys to symbols for Ruby
@@ -307,64 +312,59 @@ module FastMcp
         result, metadata = tool.new.call_with_schema_validation!(**symbolized_args)
 
         # Format and send the result
-        send_formatted_result(result, id, metadata)
+        send_formatted_result(result, id, metadata, client_id)
       rescue FastMcp::Tool::InvalidArgumentsError => e
         @logger.error("Invalid arguments for tool #{tool_name}: #{e.message}")
-        send_error_result(e.message, id)
+        send_error_result(e.message, id, client_id)
       rescue StandardError => e
         @logger.error("Error calling tool #{tool_name}: #{e.message}")
-        send_error_result("#{e.message}, #{e.backtrace.join("\n")}", id)
+        send_error_result("#{e.message}, #{e.backtrace.join("\n")}", id, client_id)
       end
     end
 
     # Format and send successful result
-    def send_formatted_result(result, id, metadata)
+    def send_formatted_result(result, id, metadata, client_id)
       # Check if the result is already in the expected format
       if result.is_a?(Hash) && result.key?(:content)
-        send_result(result, id, metadata: metadata)
+        send_result(result, id, client_id, metadata: metadata)
       else
-        # Format the result according to the MCP specification
-        formatted_result = {
-          content: [{ type: 'text', text: result.to_s }],
-          isError: false
-        }
-
-        send_result(formatted_result, id, metadata: metadata)
+        send_result({ content: result }, id, client_id, metadata: metadata)
       end
     end
 
     # Format and send error result
-    def send_error_result(message, id)
+    def send_error_result(message, id, client_id)
       # Format error according to the MCP specification
       error_result = {
         content: [{ type: 'text', text: "Error: #{message}" }],
         isError: true
       }
 
-      send_result(error_result, id)
+      send_response(error_result, client_id)
     end
 
     # Handle resources/list request
-    def handle_resources_list(id)
+    def handle_resources_list(id, context)
+      client_id = context[:client_id]
       resources_list = @resources.values.map(&:metadata)
-
-      send_result({ resources: resources_list }, id)
+      send_result({ resources: resources_list }, id, client_id)
     end
 
     # Handle resources/subscribe request
-    def handle_resources_subscribe(params, id)
+    def handle_resources_subscribe(params, id, context)
       return unless @client_initialized
 
       uri = params['uri']
+      client_id = context[:client_id]
 
       unless uri
-        send_error(-32_602, 'Invalid params: missing resource URI', id)
+        send_error(-32_602, 'Invalid params: missing resource URI', id, client_id)
         return
       end
 
       resource = @resources[uri]
       unless resource
-        send_error(-32_602, "Resource not found: #{uri}", id)
+        send_error(-32_602, "Resource not found: #{uri}", id, client_id)
         return
       end
 
@@ -372,17 +372,18 @@ module FastMcp
       @resource_subscriptions[uri] ||= []
       @resource_subscriptions[uri] << id
 
-      send_result({ subscribed: true }, id)
+      send_result({ subscribed: true }, id, client_id)
     end
 
     # Handle resources/unsubscribe request
-    def handle_resources_unsubscribe(params, id)
+    def handle_resources_unsubscribe(params, id, context)
       return unless @client_initialized
 
       uri = params['uri']
+      client_id = context[:client_id]
 
       unless uri
-        send_error(-32_602, 'Invalid params: missing resource URI', id)
+        send_error(-32_602, 'Invalid params: missing resource URI', id, client_id)
         return
       end
 
@@ -392,7 +393,7 @@ module FastMcp
         @resource_subscriptions.delete(uri) if @resource_subscriptions[uri].empty?
       end
 
-      send_result({ unsubscribed: true }, id)
+      send_result({ unsubscribed: true }, id, client_id)
     end
 
     # Notify clients about resource list changes
@@ -409,9 +410,8 @@ module FastMcp
     end
 
     # Send a JSON-RPC result response
-    def send_result(result, id, metadata: {})
+    def send_result(result, id, client_id, metadata: {})
       result[:_meta] = metadata if metadata.is_a?(Hash) && !metadata.empty?
-
       response = {
         jsonrpc: '2.0',
         id: id,
@@ -419,11 +419,11 @@ module FastMcp
       }
 
       @logger.info("Sending result: #{response.inspect}")
-      send_response(response)
+      send_response(response, client_id)
     end
 
     # Send a JSON-RPC error response
-    def send_error(code, message, id = nil)
+    def send_error(code, message, id = nil, client_id)
       response = {
         jsonrpc: '2.0',
         error: {
@@ -433,14 +433,14 @@ module FastMcp
         id: id
       }
 
-      send_response(response)
+      send_response(response, client_id)
     end
 
     # Send a JSON-RPC response
-    def send_response(response)
+    def send_response(response, client_id)
       if @transport
         @logger.debug("Sending response: #{response.inspect}")
-        @transport.send_message(response)
+        @transport.send_message_to(client_id, response)
       else
         @logger.warn("No transport available to send response: #{response.inspect}")
         @logger.warn("Transport: #{@transport.inspect}, transport_klass: #{@transport_klass.inspect}")

--- a/lib/mcp/transports/base_transport.rb
+++ b/lib/mcp/transports/base_transport.rb
@@ -32,8 +32,8 @@ module FastMcp
 
       # Process an incoming message
       # This is a helper method that can be used by subclasses
-      def process_message(message)
-        server.handle_json_request(message)
+      def process_message(message, context)
+        server.handle_json_request(message, context)
       end
     end
   end

--- a/lib/mcp/transports/rack_transport.rb
+++ b/lib/mcp/transports/rack_transport.rb
@@ -508,9 +508,8 @@ module FastMcp
         # Parse the request body
         body = request.body.read
 
-        context = extract_context_from_env(env)
-        context[:client_id] = extract_client_id(env)
-        response = process_message(body) || []
+        context = { client_id: extract_client_id(request.env) }
+        response = process_message(body, context) || []
         @logger.info("Response: #{response}")
 
         [200, { 'Content-Type' => 'application/json' }, response]

--- a/lib/mcp/transports/rack_transport.rb
+++ b/lib/mcp/transports/rack_transport.rb
@@ -389,7 +389,10 @@ module FastMcp
 
         # Send endpoint information as the first message with query parameters
         endpoint = "#{@path_prefix}/#{@messages_route}"
-        endpoint += "?#{query_string}" if query_string
+        params = []
+        params << query_string if query_string && !query_string.empty?
+        params << "client_id=#{client_id}"
+        endpoint += "?#{params.join('&')}" unless params.empty?
         @logger.debug("Sending endpoint information to client #{client_id}: #{endpoint}")
         io.write("event: endpoint\ndata: #{endpoint}\n\n")
 


### PR DESCRIPTION
Solves #40.

Adds IO messaging per client id for SSE implementation.

* Adds client_id to the endpoint response during SSE initialization.
* swaps from messaging all sse clients to specific client based on the endpoint client_id request.
* Locally tested against MCP Inspector & Cursor.

I couldn't find a specific impl for 2024-11-05 spec on SSE client session tracking. Rather it calls out that the client should respect the endpoint provided by the server.
1.  I've chosen to pass the client_id back to the client as the query parameter `client_id` in the endpoint for communication.
2. When receiving a POST to the endpoint w/ client_id query param the server knows which SSE IO to respond on.
3. Broadcast still functions as previously implemented to all clients (i.e. notifications on tool updates).
4.  [See 2024-11-05 spec on HTTP SSE](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse).

In [2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#session-management), http streaming appears to use header based approach for session ID tracking.

Draft PR: still fixing a few failing specs, but solution is functional for local testing.
