### PR TITLE
fix: undefined local variable or method "headers"

### DIFF
--- a/lib/mcp/transports/rack_transport.rb
+++ b/lib/mcp/transports/rack_transport.rb
@@ -265,7 +265,7 @@ module FastMcp
         else
           # Fallback for servers that don't support streaming
           @logger.info('Falling back to default SSE')
-          [200, SSE_HEADERS, [":ok\n\n"]]
+          [200, SSE_HEADERS.dup, [":ok\n\n"]]
         end
       end
 

--- a/lib/mcp/transports/rack_transport.rb
+++ b/lib/mcp/transports/rack_transport.rb
@@ -265,7 +265,7 @@ module FastMcp
         else
           # Fallback for servers that don't support streaming
           @logger.info('Falling back to default SSE')
-          [200, headers, [":ok\n\n"]]
+          [200, SSE_HEADERS, [":ok\n\n"]]
         end
       end
 


### PR DESCRIPTION
I got an error

```
10:31:00 web.1  | Falling back to default SSE
10:31:00 web.1  |
10:31:00 web.1  | NameError - undefined local variable or method 'headers' for an instance of FastMcp::Transports::RackTransport:
10:31:00 web.1  |
```

Here is a small fix