### PR TITLE
Lower rack dep to >= 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       dry-schema (~> 1.14)
       json (~> 2.0)
       mime-types (~> 3.4)
-      rack (~> 3.1)
+      rack (>= 2.2)
 
 GEM
   remote: https://rubygems.org/

--- a/fast-mcp.gemspec
+++ b/fast-mcp.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-schema', '~> 1.14'
   spec.add_dependency 'json', '~> 2.0'
   spec.add_dependency 'mime-types', '~> 3.4'
-  spec.add_dependency 'rack', '~> 3.1'
+  spec.add_dependency 'rack', '>= 2.2'
 
   # Development dependencies are specified in the Gemfile
 end


### PR DESCRIPTION
I'm working on incorporating fast-mcp with some legacy applications that I cannot upgrade to rack 3 at this time. I've done some preliminary testing on a fork and haven't hit any issues of fast-mcp working on rack 2.2.