### PR TITLE
Fix missing commas for params hash

### DIFF
--- a/lib/generators/fast_mcp/install/templates/fast_mcp_initializer.rb
+++ b/lib/generators/fast_mcp/install/templates/fast_mcp_initializer.rb
@@ -20,12 +20,12 @@ FastMcp.mount_in_rails(
   version: '1.0.0',
   path_prefix: '/mcp', # This is the default path prefix
   messages_route: 'messages', # This is the default route for the messages endpoint
-  sse_route: 'sse' # This is the default route for the SSE endpoint
+  sse_route: 'sse', # This is the default route for the SSE endpoint
   # Add allowed origins below, it defaults to Rails.application.config.hosts
   # allowed_origins: ['localhost', '127.0.0.1', '[::1]', 'example.com', /.*\.example\.com/],
   # localhost_only: true, # Set to false to allow connections from other hosts
   # whitelist specific ips to if you want to run on localhost and allow connections from other IPs
-  # allowed_ips: ['127.0.0.1', '::1']
+  # allowed_ips: ['127.0.0.1', '::1'],
   # authenticate: true,       # Uncomment to enable authentication
   # auth_token: 'your-token', # Required if authenticate: true
 ) do |server|


### PR DESCRIPTION
Just a small quality of life update; not having the commas breaks un-commenting the parameters below.