### PR TITLE
add hook to send errors to error monitoring tools

### DIFF
--- a/lib/fast_mcp.rb
+++ b/lib/fast_mcp.rb
@@ -39,6 +39,7 @@ module FastMcp
   # @option options [String] :messages_route The route for the messages endpoint
   # @option options [String] :sse_route The route for the SSE endpoint
   # @option options [Logger] :logger The logger to use
+  # @option options [#call] :on_error hook called in the event of an error
   # @option options [Array<String,Regexp>] :allowed_origins List of allowed origins for DNS rebinding protection
   # @yield [server] A block to configure the server
   # @yieldparam server [FastMcp::Server] The server to configure
@@ -47,8 +48,9 @@ module FastMcp
     name = options.delete(:name) || 'mcp-server'
     version = options.delete(:version) || '1.0.0'
     logger = options.delete(:logger) || Logger.new
+    on_error = options.delete(:on_error)
 
-    server = FastMcp::Server.new(name: name, version: version, logger: logger)
+    server = FastMcp::Server.new(name: name, version: version, logger: logger, on_error: on_error)
     yield server if block_given?
 
     # Store the server in the Sinatra settings if available


### PR DESCRIPTION
in addition to logging errors it would be helpful to be able to send error reports to tools like Bugsnag to help with debugging mcp tool calls

this set of changes adds a new `on_error` argument to server initialization that accepts an object that responds to the method #call

example server config with lambda:

```ruby
server = FastMcp::Server.new(
  name: 'my-ai-server',
  version: '1.0.0',
  on_error: ->(e) { Bugsnag.notify(e) }
)
```

example server config with custom error reporting class:

```ruby
class ErrorNotifier
  def self.call(error)
    Bugsnag.notify(error)
  end
end

server = FastMcp::Server.new(
  name: 'my-ai-server',
  version: '1.0.0',
  on_error: ErrorNotifier
)
```