### PR TITLE
Add trailing comma to generated initializer

### DIFF
--- a/examples/rails-demo-app/config/initializers/fast_mcp.rb
+++ b/examples/rails-demo-app/config/initializers/fast_mcp.rb
@@ -20,7 +20,7 @@ FastMcp.mount_in_rails(
   version: '1.0.0',
   path_prefix: '/mcp', # This is the default path prefix
   messages_route: 'messages', # This is the default route for the messages endpoint
-  sse_route: 'sse' # This is the default route for the SSE endpoint
+  sse_route: 'sse', # This is the default route for the SSE endpoint
   # Add allowed origins below, it defaults to Rails.application.config.hosts
   # allowed_origins: ['localhost', '127.0.0.1', 'example.com', /.*\.example\.com/],
   # authenticate: true,       # Uncomment to enable authentication

--- a/lib/generators/fast_mcp/install/templates/fast_mcp_initializer.rb
+++ b/lib/generators/fast_mcp/install/templates/fast_mcp_initializer.rb
@@ -20,7 +20,7 @@ FastMcp.mount_in_rails(
   version: '1.0.0',
   path_prefix: '/mcp', # This is the default path prefix
   messages_route: 'messages', # This is the default route for the messages endpoint
-  sse_route: 'sse' # This is the default route for the SSE endpoint
+  sse_route: 'sse', # This is the default route for the SSE endpoint
   # Add allowed origins below, it defaults to Rails.application.config.hosts
   # allowed_origins: ['localhost', '127.0.0.1', '[::1]', 'example.com', /.*\.example\.com/],
   # localhost_only: true, # Set to false to allow connections from other hosts


### PR DESCRIPTION
* the trailing comments make it harder to miss there's no trailing comma on this line