### PR TITLE
Add on_error_result server hook

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -39,6 +39,7 @@ module FastMcp
       @capabilities = DEFAULT_CAPABILITIES.dup
       @tool_filters = []
       @resource_filters = []
+      @on_error_result = nil
 
       # Merge with provided capabilities
       @capabilities.merge!(capabilities) if capabilities.is_a?(Hash)
@@ -78,6 +79,10 @@ module FastMcp
       notify_resource_list_changed if @transport
 
       resource
+    end
+
+    def on_error_result(&block)
+      @on_error_result = block
     end
 
     # Remove a resource from the server
@@ -368,6 +373,8 @@ module FastMcp
 
     # Format and send error result
     def send_error_result(message, id)
+      @on_error_result&.call(message)
+
       # Format error according to the MCP specification
       error_result = {
         content: [{ type: 'text', text: "Error: #{message}" }],

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -314,5 +314,29 @@ RSpec.describe FastMcp::Server do
         server.handle_request(request)
       end
     end
+
+    context 'with an error result' do
+      let(:on_error_result) { ->(message) { message } }
+
+      before {
+        server.on_error_result(&on_error_result)
+        allow_any_instance_of(test_tool_class).to receive(:call).and_raise('test error')
+      }
+
+      it 'calls the on_error_result block' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'test-tool',
+            arguments: { name: 'World' }
+          },
+          id: 1
+        }.to_json
+
+        expect(on_error_result).to receive(:call).with(/^test error, /)
+        server.handle_request(request)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a `on_error_result` hook to the server class. It can be used to capture errors and report them to Sentry for example 