### PR TITLE
fix tool hash call

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -450,7 +450,7 @@ module FastMcp
         result: result
       }
 
-      @logger.info("Sending result: #{response.inspect}")
+      @logger.info("Sending result: #{truncate_string(response.inspect, 1000)}")
       send_response(response)
     end
 
@@ -471,7 +471,7 @@ module FastMcp
     # Send a JSON-RPC response
     def send_response(response)
       if @transport
-        @logger.debug("Sending response: #{response.inspect}")
+        @logger.debug("Sending response: #{truncate_string(response.inspect, 1000)}")
         @transport.send_message(response)
       else
         @logger.warn("No transport available to send response: #{response.inspect}")
@@ -488,6 +488,11 @@ module FastMcp
         new_value = value.is_a?(Hash) ? symbolize_keys(value) : value
         result[new_key] = new_value
       end
+    end
+
+    def truncate_string(input, truncate_to)
+      return input unless input.length > truncate_to
+      "#{input[0, truncate_to]}..."
     end
   end
 end

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -82,19 +82,19 @@ module Dry
         # Override call method to manage nested context
         alias original_call call
 
-        def call(&block)
+        def call(*args, &block)
           if block
             # Use current context to track nested context if available
             context = MetadataContext.current
             if context
               context.with_nested(name) do
-                original_call(&block)
+                original_call(*args, &block)
               end
             else
-              original_call(&block)
+              original_call(*args, &block)
             end
           else
-            original_call(&block)
+            original_call(*args, &block)
           end
         end
       end

--- a/lib/mcp/transports/rack_transport.rb
+++ b/lib/mcp/transports/rack_transport.rb
@@ -545,10 +545,14 @@ module FastMcp
                          .transform_keys { |k| k.sub('HTTP_', '').downcase.tr('_', '-') }
 
         # Let the specific server handle the JSON request directly
-        response = server.handle_request(body, headers: headers) || []
+        response = server.handle_request(body, headers: headers)
 
         # Return the JSON response
-        [200, { 'Content-Type' => 'application/json' }, response]
+        if response.nil?
+          [202, {}, []]
+        else
+          [200, { 'Content-Type' => 'application/json' }, response]
+        end
       end
 
       # Return a method not allowed error response


### PR DESCRIPTION
dry schema macro hash `call` takes args, in order to support schema reusing:
https://dry-rb.org/gems/dry-schema/1.5/reusing-schemas/
https://github.com/dry-rb/dry-schema/blob/main/lib/dry/schema/macros/hash.rb

this fix allows such kind of usage.