### PR TITLE
Add authorize checks for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [Unreleased]
+
+### Added
+
+- Granular authorization support for resources (`resource/read`, `resource/subscribe`, `resource/unsubscribe`) and header injection for resource operations. Implements issue #106.
+
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Fast MCP solves all these problems by providing a clean, Ruby-focused implementa
 
 - 🛠️ **Tools API** - Let AI models call your Ruby functions securely, with in-depth argument validation through [Dry-Schema](https://github.com/dry-rb/dry-schema).
 - 📚 **Resources API** - Share data between your app and AI models
+  - 🔐 **Resource Authorization** - Define per-resource `authorize` blocks (read/subscribe/unsubscribe) and access request headers from within resources (Issue #106)
 - 🔄 **Multiple Transports** - Choose from STDIO, HTTP, or SSE based on your needs
 - 🧩 **Framework Integration** - Works seamlessly with Rails, Sinatra or any Rack app.
 - 🔒 **Authentication Support** - Secure your AI-powered endpoints with ease

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -23,6 +23,8 @@ The Fast MCP library supports the following resource features:
 - **Resource Notifications**: Receive notifications when resources change
 - **Binary Content**: Support for both text and binary content
 - **Resource Metadata**: Access resource metadata without reading the content
+- **Resource Authorization**: Granular access control with `authorize` blocks for read operations
+- **Request Headers Access**: Access HTTP headers in authorization and content methods
 
 ## Server-Side Usage
 
@@ -142,6 +144,66 @@ This approach ensures that:
 3. Multiple instances can be created without conflicts
 4. Resources are more suitable for distributed environments
 
+## Authorization and Access Control
+
+### Resource Authorization
+
+You can implement granular access control for resources by using the `authorize` block. Authorization is checked for the `resource/read` operation. Access is granted only if all authorization checks pass.
+
+```ruby
+class ProtectedDataResource < FastMcp::Resource
+  uri "api/protected/data"
+  resource_name "Protected Data"
+  description "A resource that requires authorization to access"
+  mime_type "application/json"
+
+  # Define authorization logic for this resource
+  authorize do
+    # Access the current user from headers
+    auth_header = headers['authorization']
+    # Perform your authorization checks
+    auth_header && auth_header.start_with?('Bearer ')
+  end
+
+  def content
+    JSON.generate({
+      data: "This is protected data",
+      accessed_at: Time.now.to_s
+    })
+  end
+end
+```
+
+### Authorization with Parameters
+
+For templated resources, you can access template parameters in the authorization block:
+
+```ruby
+class UserResourceWithParams < FastMcp::Resource
+  uri "api/users/{user_id}/profile"
+  resource_name "User Profile"
+  description "Access user profile based on user_id"
+  mime_type "application/json"
+
+  authorize do
+    # Access template parameters via self.params
+    user_id = params[:user_id]
+    auth_header = headers['authorization']
+
+    # Example: Only allow if the requested user_id matches the authenticated user
+    # In a real app, you'd decode the token and verify the user_id
+    auth_header && auth_header.include?("user_#{user_id}")
+  end
+
+  def content
+    JSON.generate({
+      user_id: params[:user_id],
+      profile: "User profile data"
+    })
+  end
+end
+```
+
 ## Integration with Web Frameworks
 
 When integrating MCP resources with web frameworks like Rails, Sinatra, or Hanami, you can use the same approach as with tools. The resources will be exposed through the Rack middleware.
@@ -167,6 +229,10 @@ For more details on integrating with web frameworks, see:
 
 7. **Security**: Be mindful of what data you expose through resources, especially in multi-tenant applications.
 
+8. **Authorization**: Use the `authorize` block to implement access control for resource/read operations only.
+
+9. **Headers in Authorization**: Use request headers (`self.headers`) to implement per-request authorization logic for read operations.
+
 ## Conclusion
 
-MCP Resources provide a powerful way to share and synchronize data between servers and clients. By keeping resources stateless and using tools for updates, you can build robust, scalable applications that work well in distributed environments. 
+MCP Resources provide a powerful way to share and synchronize data between servers and clients. By keeping resources stateless and using tools for updates, you can build robust, scalable applications that work well in distributed environments. With the addition of granular authorization support for resource/read operations, you can now implement sophisticated access control policies to protect sensitive data.

--- a/lib/mcp/resource.rb
+++ b/lib/mcp/resource.rb
@@ -61,9 +61,10 @@ module FastMcp
 
       # Initialize a new instance from the given URI
       # @param uri [String] The URI to initialize from
+      # @param headers [Hash] The HTTP headers from the request
       # @return [Resource] A new resource instance
-      def initialize_from_uri(uri)
-        new(params_from_uri(uri))
+      def initialize_from_uri(uri, headers: {})
+        new(params_from_uri(uri), headers: headers)
       end
 
       # Get the parameters from the given URI
@@ -102,6 +103,14 @@ module FastMcp
       def mime_type(value = nil)
         @mime_type = value if value
         @mime_type || (superclass.respond_to?(:mime_type) ? superclass.mime_type : nil)
+      end
+
+      # Add authorization block for this resource
+      # The block will be called to determine if access is allowed
+      # @param block [Proc] The authorization logic block
+      def authorize(&block)
+        @authorization_blocks ||= []
+        @authorization_blocks.push block
       end
 
       # Get the resource metadata (without content)
@@ -158,8 +167,10 @@ module FastMcp
 
     # Initialize with instance variables
     # @param params [Hash] The parameters for this resource instance
-    def initialize(params = {})
+    # @param headers [Hash] The HTTP headers from the request
+    def initialize(params = {}, headers: {})
       @params = params
+      @headers = headers
     end
 
     # URI of the resource - delegates to class method
@@ -189,6 +200,25 @@ module FastMcp
     # Get parameters from the URI template
     # @return [Hash] The parameters extracted from the URI
     attr_reader :params
+
+    # Get headers from the request
+    # @return [Hash] The HTTP headers from the request
+    attr_reader :headers
+
+    # Check if this resource access is authorized based on authorization blocks
+    # @return [Boolean] true if authorized, false otherwise
+    def authorized?
+      auth_checks = self.class.ancestors.filter_map do |ancestor|
+        ancestor.ancestors.include?(FastMcp::Resource) &&
+          ancestor.instance_variable_get(:@authorization_blocks)
+      end.flatten
+
+      return true if auth_checks.empty?
+
+      auth_checks.all? do |auth_check|
+        instance_exec(&auth_check)
+      end
+    end
 
     # Method to be overridden by subclasses to dynamically generate content
     # @return [String, nil] Generated content for this resource

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -171,7 +171,7 @@ module FastMcp
       when 'resources/templates/list'
         handle_resources_templates_list(id)
       when 'resources/read'
-        handle_resources_read(params, id)
+        handle_resources_read(params, id, headers: headers)
       when 'resources/subscribe'
         handle_resources_subscribe(params, id)
       when 'resources/unsubscribe'
@@ -239,7 +239,7 @@ module FastMcp
     end
 
     # Handle a resource read
-    def handle_resources_read(params, id)
+    def handle_resources_read(params, id, headers: {})
       uri = params['uri']
 
       return send_error(-32_602, 'Invalid params: missing resource URI', id) unless uri
@@ -252,10 +252,15 @@ module FastMcp
 
         @logger.debug("Found resource: #{resource.resource_name}, templated: #{resource.templated?}")
 
+        resource_instance = resource.initialize_from_uri(uri, headers: headers)
+        @logger.debug("Resource instance params: #{resource_instance.params.inspect}")
+
+        # Check authorization
+        authorized = resource_instance.authorized?
+        return send_error(-32_602, 'Unauthorized', id) unless authorized
+
         base_content = { uri: uri }
         base_content[:mimeType] = resource.mime_type if resource.mime_type
-        resource_instance = resource.initialize_from_uri(uri)
-        @logger.debug("Resource instance params: #{resource_instance.params.inspect}")
 
         result = if resource_instance.binary?
                    {

--- a/spec/mcp/resource_spec.rb
+++ b/spec/mcp/resource_spec.rb
@@ -220,4 +220,223 @@ RSpec.describe FastMcp::Resource do
       expect(resource.description).to eq('Custom description')
     end
   end
+
+  describe '#headers' do
+    let(:resource_class) do
+      Class.new(FastMcp::Resource) do
+        uri 'test/headers'
+        resource_name 'Headers Test'
+        description 'A resource that demonstrates header access'
+        mime_type 'application/json'
+
+        def content
+          {
+            message: 'Headers successfully accessed!',
+            user_agent: headers['user-agent'] || 'No User-Agent'
+          }.to_json
+        end
+      end
+    end
+
+    it 'can read headers' do
+      resource = resource_class.new(headers: { 'user-agent' => 'test-client/1.0' })
+      content = JSON.parse(resource.content)
+      expect(content['user_agent']).to eq('test-client/1.0')
+    end
+
+    it 'provides empty headers hash when none passed' do
+      resource = resource_class.new
+      expect(resource.headers).to be_a(Hash)
+      expect(resource.headers).to be_empty
+    end
+  end
+
+  describe '#authorize' do
+    context 'without authorization' do
+      let(:open_resource_class) do
+        Class.new(FastMcp::Resource) do
+          uri 'test/open'
+          resource_name 'Open Resource'
+          description 'An open resource'
+          mime_type 'text/plain'
+
+          def content
+            'Open content'
+          end
+        end
+      end
+
+      it 'returns true' do
+        resource = open_resource_class.new
+        expect(resource.authorized?).to be true
+      end
+    end
+
+    context 'with authorization' do
+      context 'without parameters' do
+        let(:token) { 'valid_token' }
+        let(:authorized_resource_class) do
+          valid_token = token
+          Class.new(FastMcp::Resource) do
+            uri 'test/protected'
+            resource_name 'Protected Resource'
+            description 'A protected resource'
+            mime_type 'text/plain'
+
+            authorize do
+              headers['AUTHORIZATION'] == valid_token
+            end
+
+            def content
+              'Protected content'
+            end
+          end
+        end
+
+        it 'returns true when authorized' do
+          resource = authorized_resource_class.new(headers: {
+                                                     'AUTHORIZATION' => token
+                                                   })
+
+          expect(resource.authorized?).to be true
+        end
+
+        it 'returns false when not authorized' do
+          resource = authorized_resource_class.new(headers: {
+                                                     'AUTHORIZATION' => 'invalid_token'
+                                                   })
+
+          expect(resource.authorized?).to be false
+        end
+      end
+
+      context 'with URI parameters' do
+        let(:token) { 'valid_token' }
+        let(:authorized_resource_class) do
+          valid_token = token
+          Class.new(FastMcp::Resource) do
+            uri 'test/user/{user_id}'
+            resource_name 'User Resource'
+            description 'A user-specific resource'
+            mime_type 'application/json'
+
+            authorize do |params|
+              headers['AUTHORIZATION'] == valid_token && params[:user_id] == '123'
+            end
+
+            def content
+              { user_id: params[:user_id] }.to_json
+            end
+          end
+        end
+
+        it 'returns true when authorized with correct parameters' do
+          resource = authorized_resource_class.new(
+            { user_id: '123' },
+            headers: { 'AUTHORIZATION' => token }
+          )
+
+          expect(resource.authorized?(user_id: '123')).to be true
+        end
+
+        it 'returns false when unauthorized with wrong parameters' do
+          resource = authorized_resource_class.new(
+            { user_id: '456' },
+            headers: { 'AUTHORIZATION' => token }
+          )
+
+          expect(resource.authorized?(user_id: '456')).to be false
+        end
+      end
+
+      context 'with inherited authorization' do
+        let(:token) { 'valid_token' }
+        let(:root_authorized_resource_class) do
+          valid_token = token
+          Class.new(FastMcp::Resource) do
+            uri 'test/base'
+            resource_name 'Base Resource'
+            description 'A base resource'
+            mime_type 'text/plain'
+
+            authorize do
+              headers['AUTHORIZATION'] == valid_token
+            end
+
+            def content
+              'Base content'
+            end
+          end
+        end
+
+        context 'with own authorization' do
+          let(:child_authorized_resource_class) do
+            Class.new(root_authorized_resource_class) do
+              uri 'test/child'
+              resource_name 'Child Resource'
+              description 'A child resource'
+
+              authorize do
+                headers['X-CUSTOM-HEADER'] == 'allowed'
+              end
+
+              def content
+                'Child content'
+              end
+            end
+          end
+
+          it 'returns true when fully authorized' do
+            resource = child_authorized_resource_class.new(headers: {
+                                                             'AUTHORIZATION' => token,
+                                                             'X-CUSTOM-HEADER' => 'allowed'
+                                                           })
+            expect(resource.authorized?).to be true
+          end
+
+          it 'returns false when failing parent authorization' do
+            resource = child_authorized_resource_class.new(headers: {
+                                                             'X-CUSTOM-HEADER' => 'allowed'
+                                                           })
+            expect(resource.authorized?).to be false
+          end
+
+          it 'returns false when failing child authorization' do
+            resource = child_authorized_resource_class.new(headers: {
+                                                             'AUTHORIZATION' => token
+                                                           })
+            expect(resource.authorized?).to be false
+          end
+        end
+
+        context 'without own authorization' do
+          let(:child_resource_class) do
+            Class.new(root_authorized_resource_class) do
+              uri 'test/child'
+              resource_name 'Child Resource'
+              description 'A child resource'
+
+              def content
+                'Child content'
+              end
+            end
+          end
+
+          it 'returns true when authorized' do
+            resource = child_resource_class.new(headers: {
+                                                  'AUTHORIZATION' => token
+                                                })
+            expect(resource.authorized?).to be true
+          end
+
+          it 'returns false when not authorized' do
+            resource = child_resource_class.new(headers: {
+                                                  'AUTHORIZATION' => 'invalid_token'
+                                                })
+            expect(resource.authorized?).to be false
+          end
+        end
+      end
+    end
+  end
 end 

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -339,4 +339,263 @@ RSpec.describe FastMcp::Server do
       end
     end
   end
+
+  describe 'resources' do
+    let(:users_resource_class) do
+      Class.new(FastMcp::Resource) do
+        uri 'file://users.json'
+        resource_name 'Users'
+        description 'List of users'
+        mime_type 'application/json'
+
+        def content
+          JSON.generate([
+            { id: 1, name: 'Alice', email: 'alice@example.com' },
+            { id: 2, name: 'Bob', email: 'bob@example.com' }
+          ])
+        end
+      end
+    end
+
+    let(:protected_resource_class) do
+      token = 'secret-token'
+      Class.new(FastMcp::Resource) do
+        uri 'file://protected.json'
+        resource_name 'Protected Resource'
+        description 'A protected resource'
+        mime_type 'application/json'
+
+        authorize do
+          headers['AUTHORIZATION'] == token
+        end
+
+        def content
+          { data: 'sensitive' }.to_json
+        end
+      end
+    end
+
+    let(:user_resource_class) do
+      Class.new(FastMcp::Resource) do
+        uri 'file://users/{user_id}'
+        resource_name 'User Resource'
+        description 'A specific user resource'
+        mime_type 'application/json'
+
+        authorize do |params|
+          headers['X-USER-ID'] == params[:user_id]
+        end
+
+        def content
+          { user_id: params[:user_id] }.to_json
+        end
+      end
+    end
+
+    before do
+      server.register_resource(users_resource_class)
+      server.register_resource(protected_resource_class)
+      server.register_resource(user_resource_class)
+      allow(server).to receive(:send_response)
+    end
+
+    describe '#handle_request with resources/read' do
+      it 'reads a resource' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: { uri: 'file://users.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_result) do |result, id|
+          expect(id).to eq(1)
+          expect(result).to have_key(:contents)
+          expect(result[:contents]).to be_an(Array)
+          expect(result[:contents][0]).to have_key(:uri)
+          expect(result[:contents][0]).to have_key(:mimeType)
+          expect(result[:contents][0]).to have_key(:text)
+        end
+
+        server.handle_request(request)
+      end
+
+      it 'returns error when resource not found' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: { uri: 'file://nonexistent.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_error).with(-32_602, /Resource not found/, 1)
+        server.handle_request(request)
+      end
+
+      it 'returns error when authorization fails' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: { uri: 'file://protected.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_error).with(-32_602, /Unauthorized/, 1)
+        server.handle_request(request)
+      end
+
+      it 'reads a protected resource with valid authorization' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: { uri: 'file://protected.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_result) do |result, id|
+          expect(id).to eq(1)
+          expect(result[:contents][0][:text]).to include('sensitive')
+        end
+
+        server.handle_request(request, headers: { 'AUTHORIZATION' => 'secret-token' })
+      end
+
+      it 'reads a templated resource with valid authorization' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: { uri: 'file://users/user123' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_result) do |result, id|
+          expect(id).to eq(1)
+          expect(result[:contents][0][:text]).to include('user123')
+        end
+
+        server.handle_request(request, headers: { 'X-USER-ID' => 'user123' })
+      end
+
+      it 'returns error for templated resource with invalid authorization' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: { uri: 'file://users/user123' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_error).with(-32_602, /Unauthorized/, 1)
+        server.handle_request(request, headers: { 'X-USER-ID' => 'user456' })
+      end
+
+      it 'passes headers to resource instance' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: { uri: 'file://users.json' },
+          id: 1
+        }.to_json
+
+        custom_resource_class = Class.new(FastMcp::Resource) do
+          uri 'file://test-headers.json'
+          resource_name 'Test Headers'
+          description 'A resource that uses headers'
+          mime_type 'application/json'
+
+          def content
+            { user_agent: headers['USER-AGENT'] }.to_json
+          end
+        end
+
+        server.register_resource(custom_resource_class)
+
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: { uri: 'file://test-headers.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_result) do |result, id|
+          expect(id).to eq(1)
+          content = JSON.parse(result[:contents][0][:text])
+          expect(content['user_agent']).to eq('test-client/1.0')
+        end
+
+        server.handle_request(request, headers: { 'USER-AGENT' => 'test-client/1.0' })
+      end
+    end
+
+    describe '#handle_request with resources/subscribe' do
+      it 'subscribes to a resource' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/subscribe',
+          params: { uri: 'file://users.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_result).with({}, 1)
+        server.handle_request(request)
+      end
+
+      it 'returns error when resource not found' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/subscribe',
+          params: { uri: 'file://nonexistent.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_error).with(-32_602, /Resource not found/, 1)
+        server.handle_request(request)
+      end
+    end
+
+    describe '#handle_request with resources/unsubscribe' do
+      it 'unsubscribes from a resource' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/unsubscribe',
+          params: { uri: 'file://users.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_result).with({}, 1)
+        server.handle_request(request)
+      end
+
+      it 'returns error when resource not found' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/unsubscribe',
+          params: { uri: 'file://nonexistent.json' },
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_error).with(-32_602, /Resource not found/, 1)
+        server.handle_request(request)
+      end
+    end
+
+    describe '#handle_request with resources/list' do
+      it 'lists all registered resources' do
+        request = {
+          jsonrpc: '2.0',
+          method: 'resources/list',
+          id: 1
+        }.to_json
+
+        expect(server).to receive(:send_result) do |result, id|
+          expect(id).to eq(1)
+          expect(result[:resources]).to be_an(Array)
+          expect(result[:resources].length).to eq(3)
+          uris = result[:resources].map { |r| r[:uri] }
+          expect(uris).to include('file://users.json', 'file://protected.json')
+        end
+
+        server.handle_request(request)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Authorization: Added per-resource authorize blocks and an authorized? check; access enforced for resources/read (Fixes #106).
* Header injection: Request headers are passed into resource instances for read operations (resource.rb, server.rb).
* Documentation: Updated CHANGELOG.md, README.md and resources.md with examples and guidance for resource authorization and header usage.
* Tests: Added/updated specs in resource_spec.rb and server_spec.rb covering authorization, templated resources, and header injection.

Fixes #106